### PR TITLE
Update watchdog for golang 1.20.6

### DIFF
--- a/src/code.cloudfoundry.org/healthchecker/watchdog/watchdog.go
+++ b/src/code.cloudfoundry.org/healthchecker/watchdog/watchdog.go
@@ -34,6 +34,7 @@ func NewWatchdog(u *url.URL, componentName string, failureCounterFileName string
 	}
 	if strings.HasPrefix(u.Host, "unix") {
 		socket := strings.TrimPrefix(u.Host, "unix")
+		u.Host = "unix"
 		client.Transport = &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 				return net.Dial("unix", socket)


### PR DESCRIPTION
Starting in golang 1.20.6, additional validations on Host headers are performed during http.NewRequest(). The current mechanism for providing the socket file name from config to watchdog is via the url Host value. Once we pull the socket file data from that we now need to reset the host header to be a valid value.