### PR TITLE
Remove dependency on .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-export REPO_NAME="$(basename $(git remote get-url origin) | sed 's/.git//g' )"
-export REPO_PATH=$PWD

--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ Based on the example, you need to add:
 - [package itself](jobs/example/spec#L10)
   - *Important*: this *MUST* match the PREFIX used when vendoring, i.e. `{PREFIX}-healthchecker`
 - [`failure_counter_file` property](jobs/example/spec#L25-L27)
+
+#### <a name="running-unit-and-integration-tests"></a> Running Unit and Integration Tests
+
+##### With Docker
+
+Running tests for this release
+
+- `./scripts/create-docker-container.bash`: This will create a docker container with appropriate mounts.
+- `./scripts/test-in-docker-locally.bash`: Create docker container and run all tests and setup in a single script.
+  - `./scripts/test-in-docker-locally.bash <package> <sub-package>`: For running tests under a specific package and/or sub-package: e.g. `./scripts/test-in-docker-locally.bash healthchcker watchdog`
+
+When inside docker container: 
+- `/repo/scripts/docker/test.bash`: This will run all tests in this release
+- `/repo/scripts/docker/test.bash healthchcker`: This will only run `healthchckers` tests
+- `/repo/scripts/docker/test.bash healthchcker integration`: This will only run `watchdog` sub-package tests for `healthchcker` package
+- `/repo/scripts/docker/tests-templates.bash`: This will run all of tests for bosh tempalates
+- `/repo/scripts/docker/lint.bash`: This will run all of linting defined for this repo.

--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -2,12 +2,13 @@
 
 set -eu
 set -o pipefail
-set -x
 
 THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-CI="${THIS_FILE_DIR}/../../../wg-app-platform-runtime-ci"
+CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+. "$CI/shared/helpers/git-helpers.bash"
+REPO_NAME=$(git_get_remote_name)
+REPO_PATH="${THIS_FILE_DIR}/../"
 unset THIS_FILE_DIR
-
 
 IMAGE="cloudfoundry/tas-runtime-build"
 

--- a/scripts/docker/test.bash
+++ b/scripts/docker/test.bash
@@ -3,6 +3,8 @@
 set -eu
 set -o pipefail
 
+. "/ci/shared/helpers/git-helpers.bash"
+
 function test() {
   local package="${1:?Provide a package}"
   local sub_package="${2:-}"
@@ -14,11 +16,17 @@ function test() {
   /ci/shared/tasks/run-bin-test/task.bash "${sub_package}"
 }
 
+pushd /repo > /dev/null
+git_configure_safe_directory
+REPO_NAME=$(git_get_remote_name)
+export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/run-bin-test/linux.yml"
+popd > /dev/null
+
 pushd / > /dev/null
 if [[ -n "${1:-}" ]]; then
   test "src/code.cloudfoundry.org/${1}" "${2:-}"
 else
-  internal_repos=$(yq '.internal_repos|join("\n")' "/ci/$REPO_NAME/index.yml")
+  internal_repos=$(yq -r '.internal_repos|.[].name' "/ci/$REPO_NAME/index.yml")
   for component in $internal_repos; do
     test "src/code.cloudfoundry.org/${component}"
   done

--- a/scripts/test-in-docker-locally.bash
+++ b/scripts/test-in-docker-locally.bash
@@ -3,8 +3,11 @@
 set -eu
 
 THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+. "$CI/shared/helpers/git-helpers.bash"
+REPO_NAME=$(git_get_remote_name)
 
-"${THIS_FILE_DIR}/docker/container.bash" -d
+"${THIS_FILE_DIR}/create-docker-container.bash" -d
 
 docker exec $REPO_NAME-docker-container '/repo/scripts/docker/test.bash' "$@"
 docker exec $REPO_NAME-docker-container '/repo/scripts/docker/lint.bash'


### PR DESCRIPTION
- Reorgnanize scripts so that it's clear which scripts are ran inside ofg docker containers and which are ran in the local workstation
- ./scripts/test-in-docker-locally.bash -> Helper to run Everything
- ./scripts/create-docker-container.bash -> Create a docker container to test and run things manually

CI PR: https://github.com/cloudfoundry/wg-app-platform-runtime-ci/pull/13