### PR TITLE
Use Server struct to address gosec G114

### DIFF
--- a/src/example-app/server.go
+++ b/src/example-app/server.go
@@ -11,13 +11,16 @@ func main() {
 	fmt.Println("listening...")
 
 	port := os.Getenv("PORT")
-
-	err := http.ListenAndServe(":"+port, nil)
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: nil,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}
 }
 
-func hello(res http.ResponseWriter, req *http.Request) {
+func hello(res http.ResponseWriter, _ *http.Request) {
 	fmt.Fprintf(res, "Hello")
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Use `Server` struct, which provides an option to specify timeout, to address gosec G114


Backward Compatibility
---------------
Breaking Change? **No**